### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Includes syntax highlighting for
 
 - Strings
 - Constants
-- Variables defined with the __equ__ directive
+- Variables defined with the `equ` directive
     - Although ARMIPS supports upper/lowercase characters, numbers and underscores in variable names, variable names will not be highlighted if they use lowercase characters (because otherwise every single word would be considered a variable name)
 - Directives
 - Labels
@@ -16,13 +16,9 @@ Includes syntax highlighting for
     
 Also:
 
-- Folding on .area/.endarea pairs
+- Folding on blocks of `.area`, `.create`, `.open`, `.if`, `.func`, `.macro`, and `.region`
 
 ![Syntax highlighting example](images/example.png)
-
-## Known Issues
-
-- Branch instructions are not recognized as instructions
 
 ## Release Notes
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -18,7 +18,19 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"],
-        [".area",".endarea"]
+        [".area", "\n.endarea"],
+        [".create", ".close"],
+        [".createfile", ".closefile"],
+        [".open", ".close"],
+        [".openfile", ".closefile"],
+        [".if", ".endif"],
+        [".ifdef", ".endif"],
+        [".ifndef", ".endif"],
+        [".func", ".endfunc"],
+        [".function", ".endfunction"],
+        [".macro", ".endmacro"],
+        [".region", ".endregion"],
+        [".autoregion", ".endautoregion"]
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
@@ -30,8 +42,8 @@
     ],
     "folding": {
         "markers": {
-            "start": "^\\s*.area\\b",
-            "end": "^\\s*.endarea\\b"
+            "start": "^\\s*\\.(area|create(file)?|open(file)?|ifn?(def)?|func(tion)?|macro|(auto)?region)(?=\\s|$)",
+            "end": "^\\s*\\.(close(file)?|end(area|if|func|macro|end(auto)?region))(?=\\s|$)"
         }
     }
 }

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -29,11 +29,11 @@
 			"patterns": [
 				{
 					"name": "keyword.control.armips",
-					"match": "(?i)\\b(equ|org|orga|defs|db|dcb|dh|dcw|dw|dcd|dd|dcq)\\b"
+					"match": "(?i)\\b(equ)\\b"
 				},
 				{
 					"name": "keyword.control.directive.normal.armips",
-					"match": "(?i)\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|org|orga|headersize|include|align|aligna|fill|skip|incbin|import|byte|db|dcb|asciiz|halfword|dh|dcw|word|dw|dcd|doubleword|dd|dcq|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)\\b"
+					"match": "(?i)(?<=^|\\s)(\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|headersize|include|align|aligna|fill|skip|incbin|import|byte|asciiz|halfword|word|doubleword|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)|\\.?(defs|orga?|dc?b|dh|dc?w|dc?d|dcq))\\b"
 				},
 				{
 					"name": "keyword.control.directive.onoff.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -83,7 +83,7 @@
 				},
 				{
 					"name": "keyword.control.directive.normal.armips",
-					"match": "(?i)(?<=^|\\s)(\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|headersize|include|align|aligna|fill|skip|incbin|import|byte|asciiz|halfword|word|doubleword|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)|\\.?(defs|orga?|dc?b|dh|dc?w|dc?d|dcq))\\b"
+					"match": "(?i)(?<=^|\\s)(\\.(open|close|func|endfunc|expfunc|ascii|loadtable|string|area|endarea|region|endregion|autoregion|endautoregion|defineregion|importobj|importlib|openfile|create|createfile|closefile|headersize|include|align|aligna|fill|skip|incbin|import|byte|asciiz|halfword|word|doubleword|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|endfunction|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little|saturn|32x)|\\.?(defs|orga?|dc?b|dh|dc?w|dc?d|dcq))\\b"
 				},
 				{
 					"name": "keyword.operator.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -37,7 +37,7 @@
 				},
 				{
 					"name": "keyword.operator.armips",
-					"match": "[\\+\\-\\*\\/(::)]"
+					"match": "[\\+\\-\\*(::)]|/(?![/*])"
 				},
 				{
 					"name": "keyword.operator.instruction.thumb.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -29,11 +29,11 @@
 			"patterns": [
 				{
 					"name": "keyword.control.armips",
-					"match": "\\b(equ|org|orga|defs|db|dcb|dh|dcw|dw|dcd|dd|dcq)\\b"
+					"match": "(?i)\\b(equ|org|orga|defs|db|dcb|dh|dcw|dw|dcd|dd|dcq)\\b"
 				},
 				{
 					"name": "keyword.control.directive.armips",
-					"match": "\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|org|orga|headersize|include|align|aligna|fill|skip|incbin|import|byte|db|dcb|asciiz|halfword|dh|dcw|word|dw|dcd|doubleword|dd|dcq|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|erroronwarning|relativeinclude|nocash|sym|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)\\b"
+					"match": "(?i)\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|org|orga|headersize|include|align|aligna|fill|skip|incbin|import|byte|db|dcb|asciiz|halfword|dh|dcw|word|dw|dcd|doubleword|dd|dcq|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|erroronwarning|relativeinclude|nocash|sym|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)\\b"
 				},
 				{
 					"name": "keyword.operator.armips",
@@ -41,11 +41,11 @@
 				},
 				{
 					"name": "keyword.operator.instruction.thumb.armips",
-					"match": "\\b(adc|add|and|asr|b|bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|bic|bl|bx|cmn|cmp|eor|ldmia|ldr|ldrb|ldrh|lsl|ldsb|ldsh|lsr|mov|mul|mvn|neg|orr|pop|push|ror|sbc|stmia|str|strb|strh|swi|sub|tst|ADC|ADD|AND|ASR|B|BCC|BCS|BEQ|BGE|BGT|BHI|BLE|BLS|BLT|BMI|BNE|BPL|BVC|BVS|BIC|BL|BX|CMN|CMP|EOR|LDMIA|LDR|LDRB|LDRH|LSL|LDSB|LDSH|LSR|MOV|MUL|MVN|NEG|ORR|POP|PUSH|ROR|SBC|STMIA|STR|STRB|STRH|SWI|SUB|TST)\\b"
+					"match": "(?i)\\b(adc|add|and|asr|b|bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|bic|bl|bx|cmn|cmp|eor|ldmia|ldr|ldrb|ldrh|lsl|ldsb|ldsh|lsr|mov|mul|mvn|neg|orr|pop|push|ror|sbc|stmia|str|strb|strh|swi|sub|tst)\\b"
 				},
 				{
 					"name": "keyword.operator.instruction.arm.armips",
-					"match": "\\b(adc|add|and|b|bic|bl|bx|cdp|cmn|cmp|eor|ldc|ldm|ldr|mcr|mla|mov|mrc|mrs|msr|mul|mvn|orr|rsb|rsc|sbc|stc|stm|str|sub|swi|swp|teq|tst|ADC|ADD|AND|B|BIC|BL|BX|CDP|CMN|CMP|EOR|LDC|LDM|LDR|MCR|MLA|MOV|MRC|MRS|MSR|MUL|MVN|ORR|RSB|RSC|SBC|STC|STM|STR|SUB|SWI|SWP|TEQ|TST)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|EQ|NE|CS|CC|MI|PL|VS|VC|HI|LS|GE|LT|GT|LE|AL)\\b"
+					"match": "(?i)\\b(adc|add|and|b|bic|bl|bx|cdp|cmn|cmp|eor|ldc|ldm|ldr|mcr|mla|mov|mrc|mrs|msr|mul|mvn|orr|rsb|rsc|sbc|stc|stm|str|sub|swi|swp|teq|tst)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)\\b"
 				}
 			]
 		},
@@ -108,12 +108,12 @@
 					"match": "^\\s*@@[a-zA-Z_][\\w_]*:\\s*"
 				},
 				{
-					"begin": "^\\s*(bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|b|bl|bx|BCC|BCS|BEQ|BGE|BGT|BHI|BLE|BLS|BLT|BMI|BNE|BPL|BVC|BVS|B|BL|BX)\\s*",
+					"begin": "(?i)^\\s*(bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|b|bl|bx)\\s*",
 					"end": "$",
 					"patterns": [
 						{
 							"name": "variable.other.register.armips",
-							"match": "\\b(r[0-9]|r1[0-5]|sp|lr|pc)\\b"
+							"match": "(?i)\\b(r[0-9]|r1[0-5]|sp|lr|pc)\\b"
 						},
 						{
 							"name": "entity.name.tag.local.armips",
@@ -142,19 +142,19 @@
 				},
 				{
 					"name": "constant.numeric.hex.armips",
-					"match": "#?-?(0x[0-9a-fA-F\\.]+|[0-9a-fA-F\\.]+h)\\b"
+					"match": "(?i)#?-?(0x[0-9A-F\\.]+|[0-9A-F\\.]+h)\\b"
 				},
 				{
 					"name": "constant.numeric.oct.armips",
-					"match": "#?-?(0o[0-7\\.]+|[0-7\\.]+o)\\b"
+					"match": "(?i)#?-?(0o[0-7\\.]+|[0-7\\.]+o)\\b"
 				},
 				{
 					"name": "constant.numeric.hex.armips",
-					"match": "#?-?(0b[01\\.]+|[01\\.]+b)\\b"
+					"match": "(?i)#?-?(0b[01\\.]+|[01\\.]+b)\\b"
 				},
 				{
 					"name": "constant.numeric.exp.armips",
-					"match": "#?-?\\b[0-9\\.]+e[\\+\\-]?[0-9]+\\b"
+					"match": "(?i)#?-?\\b[0-9\\.]+e[\\+\\-]?[0-9]+\\b"
 				}
 			]
 		},
@@ -162,11 +162,11 @@
 			"patterns": [
 				{
 					"name": "support.function.noargs.armips",
-					"match": "\\b(version\\(\\)|endianness\\(\\)|outputname\\(\\)|orga?\\(\\)|headersize\\(\\)|is(arm|thumb)\\(\\))"
+					"match": "(?i)\\b(version\\(\\)|endianness\\(\\)|outputname\\(\\)|orga?\\(\\)|headersize\\(\\)|is(arm|thumb)\\(\\))"
 				},
 				{
 					"name": "support.function.args.armips",
-					"begin": "defined\\(|file(exists|size)\\(|to(string|hex)\\(|round\\(|int\\(|float\\(|frac\\(|abs\\(|hi\\(|lo\\(|min\\(|max\\(|strlen\\(|substr\\(|regex_(match|search|extract)\\(|r?find\\(|read(byte|u8|u16|u32|u64|s8|s16|s32|s64|ascii)\\(",
+					"begin": "(?i)defined\\(|file(exists|size)\\(|to(string|hex)\\(|round\\(|int\\(|float\\(|frac\\(|abs\\(|hi\\(|lo\\(|min\\(|max\\(|strlen\\(|substr\\(|regex_(match|search|extract)\\(|r?find\\(|read(byte|u8|u16|u32|u64|s8|s16|s32|s64|ascii)\\(",
 					"end": "\\)",
 					"patterns": [
 						{

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -156,6 +156,10 @@
 				{
 					"name": "constant.numeric.exp.armips",
 					"match": "(?i)#?-?\\b[0-9\\.]+e[\\+\\-]?[0-9]+\\b"
+				},
+				{
+					"name": "constant.numeric.org.armips",
+					"match": "\\."
 				}
 			]
 		}

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -137,23 +137,11 @@
 			"patterns": [
 				{
 					"name": "support.function.noargs.armips",
-					"match": "(?i)\\b(version\\(\\)|endianness\\(\\)|outputname\\(\\)|orga?\\(\\)|headersize\\(\\)|is(arm|thumb)\\(\\))"
+					"match": "(?i)\\b(version|endianness|outputname|orga?|headersize|is(arm|thumb))(?=\\(\\))"
 				},
 				{
 					"name": "support.function.args.armips",
-					"begin": "(?i)defined\\(|file(exists|size)\\(|to(string|hex)\\(|round\\(|int\\(|float\\(|frac\\(|abs\\(|hi\\(|lo\\(|min\\(|max\\(|strlen\\(|substr\\(|regex_(match|search|extract)\\(|r?find\\(|read(byte|u8|u16|u32|u64|s8|s16|s32|s64|ascii)\\(",
-					"end": "\\)",
-					"patterns": [
-						{
-							"include": "#constants"
-						},
-						{
-							"include": "#variables"
-						},
-						{
-							"include": "#strings"
-						}
-					]
+					"match": "(?i)\\b((orga?|headersize)(?=\\()(?!\\))|(defined|file(exists|size)|to(string|hex)|round|int|float|frac|abs|hi|lo|min|max|strlen|substr|regex_(match|search|extract)|r?find|read(byte|[su](8|16|32|64))|ascii)(?=\\())"
 				}
 			]
 		}

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -32,8 +32,22 @@
 					"match": "(?i)\\b(equ|org|orga|defs|db|dcb|dh|dcw|dw|dcd|dd|dcq)\\b"
 				},
 				{
-					"name": "keyword.control.directive.armips",
-					"match": "(?i)\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|org|orga|headersize|include|align|aligna|fill|skip|incbin|import|byte|db|dcb|asciiz|halfword|dh|dcw|word|dw|dcd|doubleword|dd|dcq|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|erroronwarning|relativeinclude|nocash|sym|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)\\b"
+					"name": "keyword.control.directive.normal.armips",
+					"match": "(?i)\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|org|orga|headersize|include|align|aligna|fill|skip|incbin|import|byte|db|dcb|asciiz|halfword|dh|dcw|word|dw|dcd|doubleword|dd|dcq|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)\\b"
+				},
+				{
+					"name": "keyword.control.directive.onoff.armips",
+					"begin": "(?i)(?<=^|\\s)\\.(erroronwarning|relativeinclude|nocash|sym)(?=\\s)",
+					"end": "$",
+					"patterns": [
+						{
+							"name": "keyword.control.directive.onoff.argument.armips",
+							"match": "(?i)\\b(on|off)\\b"
+						},
+						{
+							"include": "#comments"
+						}
+					]
 				},
 				{
 					"name": "keyword.operator.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -55,11 +55,11 @@
 				},
 				{
 					"name": "keyword.operator.instruction.thumb.armips",
-					"match": "(?i)\\b(adc|add|and|asr|b|bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|bic|bl|bx|cmn|cmp|eor|ldmia|ldr|ldrb|ldrh|lsl|ldsb|ldsh|lsr|mov|mul|mvn|neg|orr|pop|push|ror|sbc|stmia|str|strb|strh|swi|sub|tst)\\b"
+					"match": "(?i)(?<=^|\\s)(adc|add|and|asr|bl|bx|b(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|nv)?|b|cmn|cmp|eor|ldmia|ldr|ldrb|ldrh|lsl|ldsb|ldsh|lsr|mov|mul|mvn|neg|orr|pop|push|ror|sbc|stmia|str|strb|strh|swi|sub|tst)(?=\\s|$)"
 				},
 				{
 					"name": "keyword.operator.instruction.arm.armips",
-					"match": "(?i)\\b(adc|add|and|b|bic|bl|bx|cdp|cmn|cmp|eor|ldc|ldm|ldr|mcr|mla|mov|mrc|mrs|msr|mul|mvn|orr|rsb|rsc|sbc|stc|stm|str|sub|swi|swp|teq|tst)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)\\b"
+					"match": "(?i)(?<=^|\\s)(adc|add|and|bic|bl|bx|b|cdp|cmn|cmp|eor|ldc|ldm|ldr|mcr|mla|mov|mrc|mrs|msr|mul|mvn|orr|rsb|rsc|sbc|stc|stm|str|sub|swi|swp|teq|tst)(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|nv)?(?=\\s|$)"
 				}
 			]
 		},

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -97,40 +97,15 @@
 			"patterns": [
 				{
 					"name": "entity.name.function.global.armips",
-					"match": "^\\s*[a-zA-Z_][\\w_]*:\\s*"
+					"match": "[a-zA-Z_][\\w_]*:?"
 				},
 				{
 					"name": "entity.name.type.static.armips",
-					"match": "^\\s*@[a-zA-Z_][\\w_]*:\\s*"
+					"match": "@[a-zA-Z_][\\w_]*:?"
 				},
 				{
 					"name": "entity.name.tag.local.armips",
-					"match": "^\\s*@@[a-zA-Z_][\\w_]*:\\s*"
-				},
-				{
-					"begin": "(?i)^\\s*(bcc|bcs|beq|bge|bgt|bhi|ble|bls|blt|bmi|bne|bpl|bvc|bvs|b|bl|bx)\\s*",
-					"end": "$",
-					"patterns": [
-						{
-							"name": "variable.other.register.armips",
-							"match": "(?i)\\b(r[0-9]|r1[0-5]|sp|lr|pc)\\b"
-						},
-						{
-							"name": "entity.name.tag.local.armips",
-							"match": "@@[a-zA-Z_][\\w_]*"
-						},
-						{
-							"name": "entity.name.type.static.armips",
-							"match": "@[a-zA-Z_][\\w_]*"
-						},
-						{
-							"name": "entity.name.function.global.armips",
-							"match": "[a-zA-Z_][\\w_]*"
-						},
-						{
-							"include": "#comments"
-						}
-					]
+					"match": "@@[a-zA-Z_][\\w_]*:?"
 				}
 			]
 		},

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -87,7 +87,7 @@
 				},
 				{
 					"name": "keyword.operator.armips",
-					"match": "[\\+\\-\\*\\/(::)]"
+					"match": "<<|>>|[=!><]=|[+\\-*/%|&\\^<>!~]"
 				},
 				{
 					"name": "keyword.operator.instruction.thumb.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -41,7 +41,7 @@
 		"strings": {
 			"name": "string.quoted.double.armips",
 			"begin": "\"",
-			"end": "\"",
+			"end": "\"|$",
 			"patterns": [
 				{
 					"name": "constant.character.escape.armips",

--- a/syntaxes/armips.tmLanguage.json
+++ b/syntaxes/armips.tmLanguage.json
@@ -3,13 +3,16 @@
 	"name": "ARMIPS",
 	"patterns": [
 		{
-			"include": "#keywords"
+			"include": "#comments"
 		},
 		{
 			"include": "#strings"
 		},
 		{
-			"include": "#comments"
+			"include": "#supports"
+		},
+		{
+			"include": "#keywords"
 		},
 		{
 			"include": "#variables"
@@ -19,21 +22,50 @@
 		},
 		{
 			"include": "#constants"
-		},
-		{
-			"include": "#supports"
 		}
 	],
 	"repository": {
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.armips",
+					"match": "(//|;).*$"
+				},	
+				{
+					"name": "comment.block.armips",
+					"begin": "/\\*",
+					"end": "\\*/"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.armips",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.armips",
+					"match": "\\\\."
+				}
+			]
+		},
+		"supports": {
+			"patterns": [
+				{
+					"name": "support.function.noargs.armips",
+					"match": "(?i)\\b(version|endianness|outputname|orga?|headersize|is(arm|thumb))(?=\\(\\))"
+				},
+				{
+					"name": "support.function.args.armips",
+					"match": "(?i)\\b((orga?|headersize)(?=\\()(?!\\))|(defined|file(exists|size)|to(string|hex)|round|int|float|frac|abs|hi|lo|min|max|strlen|substr|regex_(match|search|extract)|r?find|read(byte|[su](8|16|32|64))|ascii)(?=\\())"
+				}
+			]
+		},
 		"keywords": {
 			"patterns": [
 				{
 					"name": "keyword.control.armips",
 					"match": "(?i)\\b(equ)\\b"
-				},
-				{
-					"name": "keyword.control.directive.normal.armips",
-					"match": "(?i)(?<=^|\\s)(\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|headersize|include|align|aligna|fill|skip|incbin|import|byte|asciiz|halfword|word|doubleword|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)|\\.?(defs|orga?|dc?b|dh|dc?w|dc?d|dcq))\\b"
 				},
 				{
 					"name": "keyword.control.directive.onoff.armips",
@@ -50,8 +82,12 @@
 					]
 				},
 				{
+					"name": "keyword.control.directive.normal.armips",
+					"match": "(?i)(?<=^|\\s)(\\.(open|close|func|endfunc|ascii|loadtable|string|area|endarea|importlib|openfile|create|createfile|closefile|headersize|include|align|aligna|fill|skip|incbin|import|byte|asciiz|halfword|word|doubleword|float|double|table|stringn|str|strn|sjis|sjisn|if|ifdef|ifndef|else|elseif|elseifdef|elseifndef|endif|definelabel|function|warning|error|notice|resetdelay|fixloaddelay|loadelf|arm|thumb|pool|msg|macro|endmacro|psx|ps2|psp|n64|rsp|gba|nds|3ds|arm\\.big|arm\\.little)|\\.?(defs|orga?|dc?b|dh|dc?w|dc?d|dcq))\\b"
+				},
+				{
 					"name": "keyword.operator.armips",
-					"match": "[\\+\\-\\*(::)]|/(?![/*])"
+					"match": "[\\+\\-\\*\\/(::)]"
 				},
 				{
 					"name": "keyword.operator.instruction.thumb.armips",
@@ -60,30 +96,6 @@
 				{
 					"name": "keyword.operator.instruction.arm.armips",
 					"match": "(?i)(?<=^|\\s)(adc|add|and|bic|bl|bx|b|cdp|cmn|cmp|eor|ldc|ldm|ldr|mcr|mla|mov|mrc|mrs|msr|mul|mvn|orr|rsb|rsc|sbc|stc|stm|str|sub|swi|swp|teq|tst)(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|nv)?(?=\\s|$)"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.armips",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.armips",
-					"match": "\\\\."
-				}
-			]
-		},
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.armips",
-					"match": "(//|;).*$"
-				},	
-				{
-					"name": "comment.block.armips",
-					"begin": "/\\*",
-					"end": "\\*/"
 				}
 			]
 		},
@@ -144,18 +156,6 @@
 				{
 					"name": "constant.numeric.exp.armips",
 					"match": "(?i)#?-?\\b[0-9\\.]+e[\\+\\-]?[0-9]+\\b"
-				}
-			]
-		},
-		"supports": {
-			"patterns": [
-				{
-					"name": "support.function.noargs.armips",
-					"match": "(?i)\\b(version|endianness|outputname|orga?|headersize|is(arm|thumb))(?=\\(\\))"
-				},
-				{
-					"name": "support.function.args.armips",
-					"match": "(?i)\\b((orga?|headersize)(?=\\()(?!\\))|(defined|file(exists|size)|to(string|hex)|round|int|float|frac|abs|hi|lo|min|max|strlen|substr|regex_(match|search|extract)|r?find|read(byte|[su](8|16|32|64))|ascii)(?=\\())"
 				}
 			]
 		}


### PR DESCRIPTION
This makes various improvements, including:

* Fix `//` and `/**/` comments;
* Fix matching rule priorities;
* Add more case insensitivity where appropriate;
* Add latest ARMIPS functions and directives;
* Add more operators;
* Add more folding pairs (`.if`, `.open`, `.macro` etc.);
* Some reorganizing to reduce janky matching, e.g. after branch instructions - these are now handled generically which produces better results in my opinion. For example `add r0,=@@drawTilemap` is now able to be highlighted nicely.

**Before:**
![Code_2023-02-04_16-37-26](https://user-images.githubusercontent.com/3768851/216776190-e51b6c3c-4c91-4eb8-9707-c3c9e367bfd3.png)

**After:**
![Code_2023-02-04_16-36-55](https://user-images.githubusercontent.com/3768851/216776188-727a91c1-96ba-4390-bc84-1c15b7a9aaea.png)
